### PR TITLE
Fix create item validation bugs and add MaropeToken tests

### DIFF
--- a/Marope Marketplace/main_test.js
+++ b/Marope Marketplace/main_test.js
@@ -94,10 +94,10 @@ async function createItems() {
   const createItemDesciptionField = document.getElementById("description");
 
 
-  if (createItemFile.files.lenght ==0){
+  if (createItemFile.files.length === 0){
     alert("Please select a file!");
     return;
-  }else if (createItemNameField.value.lenght == 0){
+  }else if (createItemNameField.value.length === 0){
     alert("Please give the item a name!");
     return;
   }
@@ -142,7 +142,7 @@ async function createItems() {
 // mintNFT = async (metadataUrl) => {
 //   const receipt = await tokenContract.methods.createItem(metadataUrl).send({from: ethereum.selectedAddress})
 // console.log(receipt);
-// return receipt.events.Trancfer.returnValues.tokenId;
+// return receipt.events.Transfer.returnValues.tokenId;
 // }
 
 

--- a/contracts/test/marope_token.js
+++ b/contracts/test/marope_token.js
@@ -1,0 +1,35 @@
+const MaropeToken = artifacts.require("MaropeToken");
+
+contract("MaropeToken", (accounts) => {
+  let token;
+
+  beforeEach(async () => {
+    token = await MaropeToken.new({ from: accounts[0] });
+  });
+
+  it("assigns sequential ids when minting new items", async () => {
+    await token.createItem("ipfs://token-1", { from: accounts[0] });
+
+    const predictedSecondId = await token.createItem.call("ipfs://token-2", {
+      from: accounts[0],
+    });
+    assert.strictEqual(predictedSecondId.toString(), "2", "expected next token id to be 2");
+
+    await token.createItem("ipfs://token-2", { from: accounts[0] });
+
+    const ownerOfFirst = await token.ownerOf(1);
+    const ownerOfSecond = await token.ownerOf(2);
+
+    assert.strictEqual(ownerOfFirst, accounts[0], "minter should own token 1");
+    assert.strictEqual(ownerOfSecond, accounts[0], "minter should own token 2");
+  });
+
+  it("stores the provided URI for each token", async () => {
+    const expectedUri = "ipfs://sample-token";
+    await token.createItem(expectedUri, { from: accounts[0] });
+
+    const storedUri = await token.tokenURI(1);
+
+    assert.strictEqual(storedUri, expectedUri, "tokenURI should return the stored value");
+  });
+});

--- a/frontend/main_test.js
+++ b/frontend/main_test.js
@@ -112,10 +112,10 @@ async function createItems() {
   const createItemDesciptionField = document.getElementById("description");
 
 
-  if (createItemFile.files.lenght ==0){
+  if (createItemFile.files.length === 0){
     alert("Please select a file!");
     return;
-  }else if (createItemNameField.value.lenght == 0){
+  }else if (createItemNameField.value.length === 0){
     alert("Please give the item a name!");
     return;
   }
@@ -160,7 +160,7 @@ async function createItems() {
 // mintNFT = async (metadataUrl) => {
 //   const receipt = await tokenContract.methods.createItem(metadataUrl).send({from: ethereum.selectedAddress})
 // console.log(receipt);
-// return receipt.events.Trancfer.returnValues.tokenId;
+// return receipt.events.Transfer.returnValues.tokenId;
 // }
 
 

--- a/frontend/web3_test_integration/index.html
+++ b/frontend/web3_test_integration/index.html
@@ -18,8 +18,8 @@
       <button id="btn-login">Moralis Metamask Login</button>
 
       <h4>User profile</h4>
-      <input tpye="text" id="txtUsername" required placeholder="Enter username">
-      <input tpye="text" id="txtEmail" required placeholder="Enter email">
+      <input type="text" id="txtUsername" required placeholder="Enter username">
+      <input type="text" id="txtEmail" required placeholder="Enter email">
       <small>Optional</small>
 
       <img src="" id="imgAvatar" alt="">


### PR DESCRIPTION
## Summary
- fix the create item validation logic to use the correct `length` property and align the transfer event comment spelling
- correct the username and email input type attributes in the web3 test integration page
- add a basic Truffle test suite covering `createItem` id sequencing and stored URIs

## Testing
- npx truffle test *(fails: npm 403 Forbidden when attempting to download Truffle)*

------
https://chatgpt.com/codex/tasks/task_e_683f807d54a8832886820d70355162f4